### PR TITLE
Change the default data folder to be in Windows APPDATA directory (sa…

### DIFF
--- a/harmonica/__init__.py
+++ b/harmonica/__init__.py
@@ -3,9 +3,12 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-import os.path
+import os
 
 config = {
     'pre_existing_data_dir': '',  # ignored if empty string
-    'data_dir': os.path.join(os.path.dirname(__file__), 'data'),
+    # 'data_dir': os.path.join(os.path.dirname(__file__), 'data'),
+    # If on Windows, use the system APPDATA directory to download resources to. The Python installation may
+    # be in a protected folder. Default to the package directory if no APPDATA environment variable.
+    'data_dir':  os.path.join(os.getenv('APPDATA', os.path.dirname(os.path.dirname(__file__))), 'harmonica', 'data')
 }

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ entry_points = [
 ]
 
 
-version = '0.2.0'
+version = '0.2.1'
 # version_dict['version'] = version
 
 


### PR DESCRIPTION
…me default as before if no APPDATA environ variable). The python harmonica is installed to may be a system protected directory (e.g. "Program Files"). Auto-fetching resources fails if this is the case.